### PR TITLE
Return response as text when it cannot be parsed as json

### DIFF
--- a/accesslink/oauth2.py
+++ b/accesslink/oauth2.py
@@ -101,7 +101,7 @@ class OAuth2Client(object):
         try:
             return response.json()
         except ValueError:
-            return {}
+            return response.text
 
     def __request(self, method, **kwargs):
         kwargs = self.__build_request_kwargs(**kwargs)


### PR DESCRIPTION
Some responses contain non-JSON data, such as TCX and GPX.
Return raw text when the response is not in JSON format.