### PR TITLE
Add sleep & nightly-recharge endpoints

### DIFF
--- a/accesslink/accesslink.py
+++ b/accesslink/accesslink.py
@@ -27,6 +27,7 @@ class AccessLink(object):
         self.training_data = endpoints.TrainingData(oauth=self.oauth)
         self.physical_info = endpoints.PhysicalInfo(oauth=self.oauth)
         self.daily_activity = endpoints.DailyActivity(oauth=self.oauth)
+        self.nightly_recharge = endpoints.NightlyRecharge(oauth=self.oauth)
 
     @property
     def authorization_url(self):

--- a/accesslink/accesslink.py
+++ b/accesslink/accesslink.py
@@ -28,6 +28,7 @@ class AccessLink(object):
         self.physical_info = endpoints.PhysicalInfo(oauth=self.oauth)
         self.daily_activity = endpoints.DailyActivity(oauth=self.oauth)
         self.nightly_recharge = endpoints.NightlyRecharge(oauth=self.oauth)
+        self.sleep = endpoints.Sleep(oauth=self.oauth)
 
     @property
     def authorization_url(self):

--- a/accesslink/endpoints/__init__.py
+++ b/accesslink/endpoints/__init__.py
@@ -3,3 +3,4 @@ from .pull_notifications import PullNotifications
 from .daily_activity import DailyActivity
 from .physical_info import PhysicalInfo
 from .training_data import TrainingData
+from .nightly_recharge import NightlyRecharge

--- a/accesslink/endpoints/__init__.py
+++ b/accesslink/endpoints/__init__.py
@@ -4,3 +4,4 @@ from .daily_activity import DailyActivity
 from .physical_info import PhysicalInfo
 from .training_data import TrainingData
 from .nightly_recharge import NightlyRecharge
+from .sleep import Sleep

--- a/accesslink/endpoints/nightly_recharge.py
+++ b/accesslink/endpoints/nightly_recharge.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from datetime import datetime
+from requests import HTTPError
+from .resource import Resource
+
+
+class NightlyRecharge(Resource):
+    """This resource allows partners to access their nightly recharges information.
+
+    https://www.polar.com/accesslink-api/#nightly-recharge
+    """
+
+    def list_nightly_recharges(self, access_token):
+        """List Nightly Recharge data of user for the last 28 days.
+
+        :param access_token: access token of the user
+        """
+        return self._get(endpoint="/users/nightly-recharge",
+                              access_token=access_token)
+
+    def get_nightly_recharge_by_date(self, access_token, date=datetime.today()):
+        """Get Users Nightly Recharge data for given date.
+
+        :param access_token: access token of the user
+        :param date: datetime instance
+        """
+        try:
+            return self._get(endpoint=f"/users/nightly-recharge/{date.strftime('%Y-%m-%d')}",
+                                access_token=access_token)
+        except HTTPError:
+            return None

--- a/accesslink/endpoints/sleep.py
+++ b/accesslink/endpoints/sleep.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+from datetime import datetime
+from requests import HTTPError
+from .resource import Resource
+
+
+class Sleep(Resource):
+    """This resource allows partners to access their sleep information.
+
+    https://www.polar.com/accesslink-api/#sleep
+    """
+
+    def list_sleeps(self, access_token):
+        """List sleep data of user for the last 28 days.
+
+        :param access_token: access token of the user
+        """
+        return self._get(endpoint="/users/sleep",
+                              access_token=access_token)
+
+    def list_sleeps_available(self, access_token):
+        """Get the dates with sleep start and end times, where user has sleep data available in the last 28 days.
+
+        :param access_token: access token of the user
+        """
+        return self._get(endpoint="/users/sleep/available",
+                              access_token=access_token)
+
+    def get_sleep_by_date(self, access_token, date=datetime.today()):
+        """Get Users sleep data for given date.
+
+        :param access_token: access token of the user
+        :param date: datetime instance
+        """
+        try:
+            return self._get(endpoint=f"/users/sleep/{date.strftime('%Y-%m-%d')}",
+                                access_token=access_token)
+        except HTTPError:
+            return None

--- a/accesslink_example.py
+++ b/accesslink_example.py
@@ -39,7 +39,8 @@ class PolarAccessLinkExample(object):
                   "2) Check available data\n" +
                   "3) Revoke access token\n" +
                   "4) Today nightly recharge\n" +
-                  "5) Exit\n" +
+                  "5) Sleep\n" +
+                  "6) Exit\n" +
                   "-----------------------")
             self.get_menu_choice()
 
@@ -50,7 +51,8 @@ class PolarAccessLinkExample(object):
             "2": self.check_available_data,
             "3": self.revoke_access_token,
             "4": self.today_nightly_recharge,
-            "5": self.exit,
+            "5": self.today_sleep,
+            "6": self.exit,
         }.get(choice, self.get_menu_choice)()
 
     def get_user_information(self):
@@ -151,6 +153,16 @@ class PolarAccessLinkExample(object):
 
         print("Today nightly recharge:")
         pretty_print_json(nightly_recharge)
+
+    def today_sleep(self):
+        sleep = self.accesslink.sleep.get_sleep_by_date(access_token=self.config["access_token"])
+
+        if not sleep:
+            print("Today has no sleep")
+            return
+
+        print("Today sleep:")
+        pretty_print_json(sleep)
 
 
 if __name__ == "__main__":

--- a/accesslink_example.py
+++ b/accesslink_example.py
@@ -38,7 +38,8 @@ class PolarAccessLinkExample(object):
                   "1) Get user information\n" +
                   "2) Check available data\n" +
                   "3) Revoke access token\n" +
-                  "4) Exit\n" +
+                  "4) Today nightly recharge\n" +
+                  "5) Exit\n" +
                   "-----------------------")
             self.get_menu_choice()
 
@@ -48,7 +49,8 @@ class PolarAccessLinkExample(object):
             "1": self.get_user_information,
             "2": self.check_available_data,
             "3": self.revoke_access_token,
-            "4": self.exit
+            "4": self.today_nightly_recharge,
+            "5": self.exit,
         }.get(choice, self.get_menu_choice)()
 
     def get_user_information(self):
@@ -139,6 +141,16 @@ class PolarAccessLinkExample(object):
             pretty_print_json(physical_info)
 
         transaction.commit()
+
+    def today_nightly_recharge(self):
+        nightly_recharge = self.accesslink.nightly_recharge.get_nightly_recharge_by_date(access_token=self.config["access_token"])
+
+        if not nightly_recharge:
+            print("Today has no nightly recharge")
+            return
+
+        print("Today nightly recharge:")
+        pretty_print_json(nightly_recharge)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The accesslink-api adds 2 new endpoints that are not yet develop.

Add them with a simple example to retrieve today sleep & nightly recharge.