### PR TITLE
yaml loader patched

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -6,8 +6,8 @@ import yaml
 
 def load_config(filename):
     """Load configuration from a yaml file"""
-    with open(filename) as f:
-        return yaml.load(f)
+    with open(filename, "r") as f:
+        return yaml.safe_load(f)
 
 
 def save_config(config, filename):


### PR DESCRIPTION
yaml.load(f) returned:
TypeError: load() missing 1 required positional argument: 'Loader'

yaml.safe_load(f) solves the issue.

python version: 3.10
yaml version:     6.0